### PR TITLE
Bugfix: Course header image

### DIFF
--- a/frontend/src/components/AboutCourse/CourseHeader.tsx
+++ b/frontend/src/components/AboutCourse/CourseHeader.tsx
@@ -9,11 +9,11 @@ interface CourseHeaderProps {
 const CourseHeader: FC<CourseHeaderProps> = ({ title, description, image }) => {
   return (
     <>
-      <section className="rounded-2xl no-elevate bg-surface text-on-primary-container flex flex-col gap-5 basis-4/6 px-12 py-16 col-span-4">
+      <section className="rounded-2xl no-elevate bg-surface text-on-primary-container flex flex-col gap-5 basis-4/6 px-12 py-16 col-span-4 grow shrink">
         <h1 className="text-5xl font-semibold">{title}</h1>
         <p>{description}</p>
       </section>
-      <img className="round col-span-3 h-[100%] w-[100%] rounded-2xl basis-2/6" src={image} alt="Course illustration" />
+      <img className="round col-span-3 h-full w-full rounded-2xl basis-2/6 shrink-0 grow-0 max-w-[33.3%]" src={image} alt="Course illustration" />
     </>
   );
 };


### PR DESCRIPTION
Add max-w to course header image to prevent it from growing above flex-basis 2/6 (33%)